### PR TITLE
修复ActionDialog不能上下居中的问题

### DIFF
--- a/src/ActionDialog.js
+++ b/src/ActionDialog.js
@@ -67,8 +67,6 @@ define(
                 panel.on(
                     'actionattach',
                     function () {
-                        this.resize();
-
                         if (this.autoClose) {
                             // 当子Action处理完成后对话框也一起销毁
                             var action = this.get('action');
@@ -80,6 +78,15 @@ define(
                         }
 
                         this.fire('actionattach');
+                    },
+                    this
+                );
+
+                // action enter完毕时，resize一下窗口
+                panel.on(
+                    'actionloaded',
+                    function () {
+                        this.resize();
                     },
                     this
                 );


### PR DESCRIPTION
1. 移除actionattach事件处理函数中的resize代码
2. 监听body的actionloaded事件，resize dialog。

[ActionDialog计算位置的问题](https://github.com/ecomfe/ef/issues/28)