### PR TITLE
修复 ActionDialog 无法正常初始化静态 foot 内容的问题

### DIFF
--- a/src/ActionDialog.js
+++ b/src/ActionDialog.js
@@ -108,6 +108,8 @@ define(
                 Event.delegate(panel, this, 'actionloaded');
                 Event.delegate(panel, this, 'actionloadfail');
                 Event.delegate(panel, this, 'actionloadabort');
+            } else {
+                this.main.appendChild(mainDOM);
             }
 
             panel.render();

--- a/src/ActionDialog.js
+++ b/src/ActionDialog.js
@@ -108,7 +108,8 @@ define(
                 Event.delegate(panel, this, 'actionloaded');
                 Event.delegate(panel, this, 'actionloadfail');
                 Event.delegate(panel, this, 'actionloadabort');
-            } else {
+            }
+            else {
                 this.main.appendChild(mainDOM);
             }
 


### PR DESCRIPTION
之前那个 PR 漏了一段，只做了 extraction，没有 append 进去。补上。
